### PR TITLE
Add Homebrew installation instructions for macOS users

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ Just [download](https://github.com/na-ka-na/ExcelCompare/releases) the zip file.
 
 Extract it anywhere (and optionally you add the bin folder to PATH).
 
+### macOS
+
+[Homebrew](http://brew.sh/) makes it easy to install ExcelCompare:
+
+    $ brew update
+    $ brew install excel-compare
+
 ## Usage
 
     $ excel_cmp <diff-flags> <file1> <file2> [--ignore1 <sheet-ignore-spec> ..] [--ignore2 <sheet-ignore-spec> ..]


### PR DESCRIPTION
ExcelCompare was added to Homebrew's core Formula repository in https://github.com/Homebrew/homebrew-core/pull/7678.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/na-ka-na/excelcompare/40)
<!-- Reviewable:end -->
