### PR TITLE
Provide functionality for MinGW

### DIFF
--- a/scripts/excel_cmp
+++ b/scripts/excel_cmp
@@ -1,8 +1,21 @@
 #!/usr/bin/env sh
 
-if [ -L $0 ];then
-  dir=`readlink -f $0|xargs dirname`
-else
-  dir=`dirname $0`
-fi
-java -ea -cp "$dir/dist/*" com.ka.spreadsheet.diff.SpreadSheetDiffer "$@"
+unamekernel="$(uname -s)"
+
+case "${unamekernel}" in
+  MINGW64*)
+    dir="$(readlink -f "$0"|xargs -d '\n' dirname)"
+    jarfiles="$(find "${dir}/dist" -name *.jar | tr '\n' ':')"
+    jarfiles=${jarfiles%?}
+    ;;
+  *)
+    if [ -L $0 ];then
+      dir=`readlink -f $0|xargs dirname`
+    else
+      dir=`dirname $0`
+    fi
+    jarfiles="$dir/dist/*"
+    ;;
+esac
+
+java -ea -cp "$jarfiles" com.ka.spreadsheet.diff.SpreadSheetDiffer "$@"


### PR DESCRIPTION
MinGW bash is the default command line interface provided by Git for
Windows. Therefore, integrating its compatibility with excel_cmp is
helpful.

In MinGW, the existing shell script excel_cmp doesn't work because of
an incompatibility with the passing the class paths for java.

The rules to follow when calling jre from MinGW are unclear. So getting
it to work takes a bit of guess work. However, it seems that
	1) Glob characters and directories don't work. So we need to pass
		each jar file individually;
	2) While it appears that quoting the individual paths doesn't work,
		quoting the entire argument does;
	3) Relative paths work when there is a single jar file passed, but
		not when there is more than one.
Therefore, each jar file is passed individually as an absolute path.

This pull request performs this.
