### PR TITLE
Make Windows smoke tests actually work.  

### DIFF
--- a/test/com/ka/spreadsheet/diff/SpreadSheetDifferSmokeTest.java
+++ b/test/com/ka/spreadsheet/diff/SpreadSheetDifferSmokeTest.java
@@ -129,7 +129,13 @@ public class SpreadSheetDifferSmokeTest {
   }
 
   private static File resultFile(String resultFile) {
-    return new File(isWindows ? ("win_" + resultFile) : resultFile);
+    if (isWindows) {
+      File tempFile = new File(resultFile);
+      String dir = tempFile.getParent();
+      String filename = "win_" + tempFile.getName();
+      resultFile = dir + File.separator + filename;
+    }
+    return new File(resultFile);
   }
 
   public static void testDiff(String testName, String[] args, @Nullable File expectedOutFile,


### PR DESCRIPTION
Commit d84fc32f2c116cdd0830c9a377ceb666ed56d9ed `Remove code duplication` incorrectly changed the names for `win_*` test resource files when there are pathnames in the filenames, as `ant test` will do, causing all tests to fail when run under Windows.