### PR TITLE
Make it easier to tell which output stream is failing a smoke test.

### DIFF
--- a/test/com/ka/spreadsheet/diff/SpreadSheetDifferSmokeTest.java
+++ b/test/com/ka/spreadsheet/diff/SpreadSheetDifferSmokeTest.java
@@ -167,8 +167,8 @@ public class SpreadSheetDifferSmokeTest {
         out.close();
     }
     assertTrue(testCompleted);
-    verifyFileContentsSame(errFile, expectedErrFile);
-    verifyFileContentsSame(outFile, expectedOutFile);
+    verifyFileContentsSame("Err", errFile, expectedErrFile);
+    verifyFileContentsSame("Out", outFile, expectedOutFile);
     System.err.println("passed");
   }
 }

--- a/test/com/ka/spreadsheet/diff/TestUtils.java
+++ b/test/com/ka/spreadsheet/diff/TestUtils.java
@@ -13,7 +13,7 @@ public class TestUtils {
   /**
    * Treat nulls as empty files.
    */
-  public static void verifyFileContentsSame(@Nullable File actual, @Nullable File expected)
+  public static void verifyFileContentsSame(String stream, @Nullable File actual, @Nullable File expected)
       throws IOException {
     LinkedList<String> actualLines =
         actual == null ? new LinkedList<String>() : readFileIntoLines(actual);
@@ -25,7 +25,7 @@ public class TestUtils {
       if ((actualLine == null) && (expectedLine == null)) {
         break;
       }
-      assertEquals("Line " + lineNum + " differs", actualLine, expectedLine);
+      assertEquals(stream + " line " + lineNum + " differs", actualLine, expectedLine);
     }
   }
 


### PR DESCRIPTION
Add the stream name ("Out" or "Err") to the line-equality assertion, so we can know which stream is in error.